### PR TITLE
feat: init Next.js + Tailwind and add /home-min from layout.json

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,5 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+html[dir="rtl"] { direction: rtl; }
+body { background:#0B0B0B; color:#fff; }

--- a/app/home-min/page.tsx
+++ b/app/home-min/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+import Image from "next/image";
+import { useState } from "react";
+
+export default function HomeMin() {
+  const [showSearch, setShowSearch] = useState(false);
+  const notifCount = 3;          // لإظهار الجرس
+  const isSubscriber = false;    // لإظهار البانر
+
+  return (
+    <main className="mx-auto max-w-md">
+      {/* Header (0,10) */}
+      <header className="w-full h-14 bg-header flex items-center justify-between px-4">
+        <button className="h-6 px-2 rounded-8 bg-btn">🌐</button>
+        <div className="flex-1 flex justify-center">
+          <Image src="/assets/logo.svg" alt="شعار" width={96} height={32} />
+        </div>
+        {notifCount > 0 ? (
+          <button className="h-6 px-2 rounded-8 bg-btn">🔔</button>
+        ) : <span className="w-6" />}
+      </header>
+
+      {/* زر فتح البحث (0,1) */}
+      <div className="px-4 mt-4">
+        <button
+          onClick={() => setShowSearch(true)}
+          className="w-full h-11 bg-[#1F1F1F] text-muted rounded-8 px-3"
+        >
+          🔍 ابحث عن صالون أو حلاق أو مدينة…
+        </button>
+      </div>
+
+      {/* بانر الاشتراك (0,1) */}
+      {!isSubscriber && (
+        <div className="px-4 mt-3">
+          <div className="w-full h-10 bg-banner text-text rounded-8 px-3 flex items-center">
+            ✨ اشترك الآن بـ 3.89€
+          </div>
+        </div>
+      )}
+
+      {/* نافذة البحث (*,20) — اختبار بسيط */}
+      {showSearch && (
+        <div className="fixed inset-0 z-50 bg-black/60 flex justify-center items-start pt-10">
+          <div className="w-[92%] max-w-md bg-white text-black rounded-8 p-4 shadow-soft">
+            <input className="w-full h-10 border rounded-8 px-2" placeholder="ابحث عن صالون أو حلاق أو مدينة…" />
+            <div className="mt-3 flex gap-2">
+              <button className="flex-1 h-11 rounded-8 bg-blue-500 text-white">ابحث الآن</button>
+              <button className="h-11 px-4 rounded-8 bg-gray-200" onClick={() => setShowSearch(false)}>إلغاء</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,9 @@
+import "./globals.css";
+export const metadata = { title: "CoifTime" };
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="ar" dir="rtl">
+      <body className="min-h-screen">{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl font-semibold">CoifTime 🚀</h1>
+      <a className="text-blue-400 underline mt-4 inline-block" href="/home-min">اذهب إلى /home-min</a>
+    </main>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+
+export {};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "coiftime",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5",
+    "tailwindcss": "3.4.7",
+    "postcss": "8.4.38",
+    "autoprefixer": "10.4.19",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5"
+  },
+  "engines": { "node": ">=18" }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,1 @@
+module.exports = { plugins: { tailwindcss: {}, autoprefixer: {} } };

--- a/public/assets/logo.svg
+++ b/public/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="32" viewBox="0 0 120 32" fill="none">
+  <rect width="120" height="32" rx="8" fill="#ffffff" fill-opacity=".1"/>
+  <text x="60" y="16" dominant-baseline="middle" text-anchor="middle" fill="#ffffff" font-family="system-ui,sans-serif" font-size="14">CoifTime</text>
+</svg>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,20 @@
+import type { Config } from "tailwindcss";
+const config: Config = {
+  content: ["./app/**/*.{ts,tsx}","./components/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        body: "#0B0B0B",
+        text: "#111827",
+        muted: "#6B7280",
+        header: "#111111",
+        banner: "#FEF3C7",
+        btn: "#222222"
+      },
+      borderRadius: { "8": "8px" },
+      boxShadow: { soft: "0 2px 8px rgba(0,0,0,.12)" }
+    }
+  },
+  plugins: []
+};
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020","DOM","DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts","**/*.ts","**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- bootstrap Next.js app with TypeScript and Tailwind config
- add basic root layout and homepage
- implement /home-min screen based on layout.json design

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acb6a7c4b08326a3b7ac106d0ec68b