### PR TITLE
feat: init Next.js + Tailwind and add /home-min

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,12 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html {
+  direction: rtl;
+}
+
+body {
+  background-color: #0B0B0B;
+  color: #ffffff;
+}

--- a/app/home-min/page.tsx
+++ b/app/home-min/page.tsx
@@ -1,0 +1,28 @@
+export default function HomeMin() {
+  const notifCount = 3
+  const isSubscriber = false
+
+  return (
+    <div className="p-4 space-y-4">
+      <header className="grid grid-cols-3 items-center h-14 px-4 bg-header">
+        <button className="justify-self-start bg-button text-white px-2 py-1 rounded-lg">🌐</button>
+        <img src="/assets/logo.svg" alt="CoifTime" className="h-8 justify-self-center" />
+        {notifCount > 0 ? (
+          <button className="justify-self-end bg-button text-white px-2 py-1 rounded-lg">🔔</button>
+        ) : (
+          <span className="justify-self-end" />
+        )}
+      </header>
+
+      <button className="w-full h-11 px-3 py-2 rounded-lg bg-searchBg text-search text-right">
+        🔍 ابحث عن صالون أو حلاق أو مدينة…
+      </button>
+
+      {!isSubscriber && (
+        <div className="w-full px-3 py-2 rounded-lg bg-bannerBg text-bannerText text-right">
+          ✨ اشترك الآن بـ 3.89€
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css'
+import type { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="ar" dir="rtl">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">CoifTime 🚀</h1>
+      <Link href="/home-min" className="text-blue-400 underline">
+        اذهب إلى الصفحة المصغرة
+      </Link>
+    </main>
+  )
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,1 @@
+export default {}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "coiftime",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "autoprefixer": "10.4.16",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.2",
+    "next": "14.2.2",
+    "postcss": "8.4.24",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "3.4.4",
+    "typescript": "5.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "24.3.0",
+    "@types/react": "19.1.11"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/public/assets/logo.svg
+++ b/public/assets/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="currentColor">
+  <circle cx="50" cy="50" r="40" />
+</svg>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,24 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: '#0B0B0B',
+        header: '#111111',
+        button: '#222222',
+        search: '#6B7280',
+        searchBg: '#1F1F1F',
+        bannerText: '#111827',
+        bannerBg: '#FEF3C7',
+      },
+    },
+  },
+  plugins: [],
+}
+
+export default config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.cjs",
+    "**/*.mjs",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 app with Tailwind, TypeScript and ESLint
- add Arabic RTL layout and basic pages including /home-min
- include Tailwind theme colors and placeholder logo

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acba68249c83268668fb436f2fa563