### PR TITLE
refactor: remove unused import

### DIFF
--- a/app/home-min/page.tsx
+++ b/app/home-min/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 /**
  * صفحة: حساب الصالون (نسخة Next.js + Tailwind)


### PR DESCRIPTION
## Summary
- remove unused `useMemo` import from home-min page

## Testing
- `npx tsc --noEmit`
- `npm run build`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68acd327e2f08326b2955990015a3fd6